### PR TITLE
Destroy non-live playlists

### DIFF
--- a/app/controllers/plays_controller.rb
+++ b/app/controllers/plays_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class PlaysController < ApplicationController
   def index
-    @recent = Play.includes(track: [:tune, :station, :origin]).
+    @recent = Play.includes(:tune, :station, :origin).
               order('created_at DESC').limit(10)
   end
 end

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class TracksController < ApplicationController
+  # Deprecated, to be removed in future
   def play
     track = Track.find_by_uuid(params[:id])
-    track.log_play
-    redirect_to track.uri
+    redirect_to play_tune_url(id: track.tune.uuid, station_id: track.station.id)
   end
 end

--- a/app/controllers/tunes_controller.rb
+++ b/app/controllers/tunes_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class TunesController < ApplicationController
   def play
     tune = Tune.find_by_uuid!(params[:id])

--- a/app/controllers/tunes_controller.rb
+++ b/app/controllers/tunes_controller.rb
@@ -1,0 +1,8 @@
+class TunesController < ApplicationController
+  def play
+    tune = Tune.find_by_uuid(params[:id])
+    station_id = Station.find_by_id(params[:station_id])
+    Play.create(station: station_id, tune: tune)
+    redirect_to tune.uri
+  end
+end

--- a/app/controllers/tunes_controller.rb
+++ b/app/controllers/tunes_controller.rb
@@ -1,6 +1,6 @@
 class TunesController < ApplicationController
   def play
-    tune = Tune.find_by_uuid(params[:id])
+    tune = Tune.find_by_uuid!(params[:id])
     station_id = Station.find_by_id(params[:station_id])
     Play.create(station: station_id, tune: tune)
     redirect_to tune.uri

--- a/app/jobs/make_playlist_live_job.rb
+++ b/app/jobs/make_playlist_live_job.rb
@@ -15,9 +15,7 @@ class MakePlaylistLiveJob < ApplicationJob
     playlist.save!
 
     other_station_playlists = Playlist.where(station_id: playlist.station_id).where.not(id: playlist_id)
-    other_station_playlists.find_each do |other_playlist|
-      other_playlist.destroy
-    end
+    other_station_playlists.find_each(&:destroy)
   rescue ActiveRecord::RecordNotFound
     # Playlist has gone away, so we can't make it live, but that's OK
   end

--- a/app/jobs/make_playlist_live_job.rb
+++ b/app/jobs/make_playlist_live_job.rb
@@ -15,7 +15,9 @@ class MakePlaylistLiveJob < ApplicationJob
     playlist.save!
 
     other_station_playlists = Playlist.where(station_id: playlist.station_id).where.not(id: playlist_id)
-    other_station_playlists.update_all(live: false)
+    other_station_playlists.find_each do |other_playlist|
+      other_playlist.destroy
+    end
   rescue ActiveRecord::RecordNotFound
     # Playlist has gone away, so we can't make it live, but that's OK
   end

--- a/app/models/play.rb
+++ b/app/models/play.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Play < ApplicationRecord
-  belongs_to :track
-  has_one :station, through: :track
-
-  validates :track_id, presence: true
+  belongs_to :station
+  belongs_to :tune
+  has_one :origin, through: :tune
 end

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -4,6 +4,7 @@
 class Station < ApplicationRecord
   has_many :playlists, dependent: :destroy
   has_one :playlist, -> { where(live: true).order('created_at DESC') }
+  has_many :plays, dependent: :nullify
 
   validates :name, :api_query, :slug, presence: true
   validates :name, :slug, uniqueness: { scope: :theme_type }
@@ -17,9 +18,5 @@ class Station < ApplicationRecord
 
   def playlist_length
     @playlist_length ||= (playlist.present? ? playlist.tracks.count : 0)
-  end
-
-  def plays
-    Play.joins(:station).where('station_id = ?', self).count
   end
 end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -7,7 +7,6 @@ class Track < ApplicationRecord
 
   has_one :origin, through: :tune
   has_one :station, through: :playlist
-  has_many :plays
 
   delegate :metadata, :thumbnail, :uri, :title, :creator, :europeana_record_id,
            :edm_rights, :edm_rights_label, :provider, to: :tune
@@ -35,9 +34,5 @@ class Track < ApplicationRecord
 
   def to_param
     uuid
-  end
-
-  def log_play
-    Play.create!(track: self)
   end
 end

--- a/app/models/tune.rb
+++ b/app/models/tune.rb
@@ -7,11 +7,21 @@ class Tune < ApplicationRecord
   belongs_to :origin
   has_many :tracks
   has_many :playlists, through: :tracks
+  has_many :plays, dependent: :nullify
 
-  validates :origin_id, :web_resource_uri, presence: true
+  validates :origin_id, :web_resource_uri, :uuid, presence: true
   validates :web_resource_uri, uniqueness: true
 
   delegate :title, :thumbnail, :europeana_record_id, :provider, to: :origin
+
+  before_validation do |tune|
+    while tune.uuid.nil?
+      tune.uuid = SecureRandom.uuid
+      if Tune.where(uuid: tune.uuid).count > 0
+        tune.uuid = nil
+      end
+    end
+  end
 
   def uri
     web_resource_uri

--- a/app/models/tune.rb
+++ b/app/models/tune.rb
@@ -17,7 +17,7 @@ class Tune < ApplicationRecord
   before_validation do |tune|
     while tune.uuid.nil?
       tune.uuid = SecureRandom.uuid
-      if Tune.where(uuid: tune.uuid).count > 0
+      if Tune.where(uuid: tune.uuid).count.positive?
         tune.uuid = nil
       end
     end

--- a/app/views/plays/index.json.jbuilder
+++ b/app/views/plays/index.json.jbuilder
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 json.plays @recent do |play|
-  json.station play.track.station.name
-  json.audio play.track.uri
-  json.title play.track.title
-  json.europeanaId play.track.europeana_record_id
-  json.provider play.track.provider
+  json.station play.station.nil? ? nil : play.station.name
+  json.audio play.tune.uri
+  json.title play.tune.title
+  json.europeanaId play.tune.europeana_record_id
+  json.provider play.tune.provider
   json.playedAt play.created_at
 end

--- a/app/views/stations/index.json.jbuilder
+++ b/app/views/stations/index.json.jbuilder
@@ -3,5 +3,5 @@ json.stations @stations do |station|
   json.name station.name
   json.link send(:"#{station.theme_type}_station_url", slug: station.slug, format: 'json')
   json.totalResults station.playlist_length
-  json.totalPlays station.plays
+  json.totalPlays station.plays.count
 end

--- a/app/views/stations/show.json.jbuilder
+++ b/app/views/stations/show.json.jbuilder
@@ -3,10 +3,9 @@ json.station do
   json.name @station.name
   json.link send(:"#{@station.theme_type}_station_url", slug: @station.slug, format: 'json')
   json.totalResults @total_tracks
-  # json.totalPlays @station.plays
   json.playlist @tracks do |track|
     if track.is_a?(Track)
-      json.audio play_track_url(track)
+      json.audio play_tune_url(id: track.tune.uuid, station_id: track.station.id)
       json.title track.title
       json.creator track.creator
       json.thumbnail track.thumbnail

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,11 @@ Rails.application.routes.draw do
   get '/stations/classical(.:format)', to: redirect('/stations/genres/classical.%{format}')
   get '/stations/folk(.:format)', to: redirect('/stations/genres/folk.%{format}')
 
+  resources :tunes, only: [] do
+    get :play, on: :member
+  end
+
+  # Deprecated, to be removed in future
   resources :tracks, only: [] do
     get :play, on: :member
   end

--- a/db/migrate/20161129133309_change_play_associations.rb
+++ b/db/migrate/20161129133309_change_play_associations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ChangePlayAssociations < ActiveRecord::Migration[5.0]
   def up
     add_column :plays, :station_id, :integer

--- a/db/migrate/20161129133309_change_play_associations.rb
+++ b/db/migrate/20161129133309_change_play_associations.rb
@@ -1,0 +1,17 @@
+class ChangePlayAssociations < ActiveRecord::Migration[5.0]
+  def up
+    add_column :plays, :station_id, :integer
+    add_index :plays, :station_id
+    add_column :plays, :tune_id, :integer
+    add_index :plays, :tune_id
+    execute('UPDATE plays SET station_id=sub.station_id, tune_id=sub.tune_id FROM (SELECT plays.id play_id, tracks.tune_id tune_id, playlists.station_id station_id FROM plays INNER JOIN tracks ON plays.track_id=tracks.id INNER JOIN playlists ON tracks.playlist_id=playlists.id) sub WHERE plays.id=sub.play_id')
+    remove_column :plays, :track_id
+  end
+
+  def down
+    remove_column :plays, :station_id
+    remove_column :plays, :tune_id
+    add_column :plays, :track_id, :integer
+    add_index :plays, :track_id
+  end
+end

--- a/db/migrate/20161129142335_add_uuid_to_tune.rb
+++ b/db/migrate/20161129142335_add_uuid_to_tune.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
 class AddUuidToTune < ActiveRecord::Migration[5.0]
   def up
     add_column :tunes, :uuid, :string
     add_index :tunes, :uuid, unique: true
 
     Tune.where(uuid: nil).find_each do |tune|
-      while tune.uuid.nil? || Tune.where(uuid: tune.uuid).count > 0
+      while tune.uuid.nil? || Tune.where(uuid: tune.uuid).count.positive?
         tune.uuid = SecureRandom.uuid
       end
       tune.save!

--- a/db/migrate/20161129142335_add_uuid_to_tune.rb
+++ b/db/migrate/20161129142335_add_uuid_to_tune.rb
@@ -1,0 +1,19 @@
+class AddUuidToTune < ActiveRecord::Migration[5.0]
+  def up
+    add_column :tunes, :uuid, :string
+    add_index :tunes, :uuid, unique: true
+
+    Tune.where(uuid: nil).find_each do |tune|
+      while tune.uuid.nil? || Tune.where(uuid: tune.uuid).count > 0
+        tune.uuid = SecureRandom.uuid
+      end
+      tune.save!
+    end
+
+    change_column :tunes, :uuid, :string, null: false
+  end
+
+  def down
+    remove_column :tunes, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161129115119) do
+ActiveRecord::Schema.define(version: 20161129142335) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,8 +33,10 @@ ActiveRecord::Schema.define(version: 20161129115119) do
   create_table "plays", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer  "track_id"
-    t.index ["track_id"], name: "index_plays_on_track_id", using: :btree
+    t.integer  "station_id"
+    t.integer  "tune_id"
+    t.index ["station_id"], name: "index_plays_on_station_id", using: :btree
+    t.index ["tune_id"], name: "index_plays_on_tune_id", using: :btree
   end
 
   create_table "stations", force: :cascade do |t|
@@ -66,7 +68,9 @@ ActiveRecord::Schema.define(version: 20161129115119) do
     t.string   "web_resource_uri"
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
+    t.string   "uuid",             null: false
     t.index ["origin_id"], name: "index_tunes_on_origin_id", using: :btree
+    t.index ["uuid"], name: "index_tunes_on_uuid", unique: true, using: :btree
     t.index ["web_resource_uri"], name: "index_tunes_on_web_resource_uri", unique: true, using: :btree
   end
 

--- a/test/controllers/tunes_controller_test.rb
+++ b/test/controllers/tunes_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TunesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/tunes_controller_test.rb
+++ b/test/controllers/tunes_controller_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class TunesControllerTest < ActionDispatch::IntegrationTest

--- a/test/fixtures/tunes.yml
+++ b/test/fixtures/tunes.yml
@@ -3,7 +3,9 @@
 one:
   origin: one
   web_resource_uri: http://provider.example.com/abc/123
+  uuid: 3b9f4d49-7e56-4177-bf4f-045f52c4bcc9
 
 two:
   origin: two
   web_resource_uri: http://provider.example.com/abc/124
+  uuid: 2336b61e-14ba-46f8-bb9f-f23cc92faeb4

--- a/test/models/play_test.rb
+++ b/test/models/play_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class PlayTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  should belong_to(:station)
+  should belong_to(:tune)
+  should have_one(:origin).through(:tune)
 end

--- a/test/models/station_test.rb
+++ b/test/models/station_test.rb
@@ -8,6 +8,7 @@ class StationTest < ActiveSupport::TestCase
   should validate_presence_of(:slug)
   should validate_uniqueness_of(:slug).scoped_to(:theme_type)
   should have_many(:playlists).dependent(:destroy)
+  should have_many(:plays).dependent(:nullify)
   should define_enum_for(:theme_type).with([:genre, :institution])
 
   test 'should generate slug from name' do

--- a/test/models/tune_test.rb
+++ b/test/models/tune_test.rb
@@ -6,4 +6,5 @@ class TuneTest < ActiveSupport::TestCase
   should validate_uniqueness_of(:web_resource_uri)
   should validate_presence_of(:origin_id)
   should belong_to(:origin)
+  should have_many(:plays).dependent(:nullify)
 end


### PR DESCRIPTION
Involving a switch to recording station and tune IDs on plays, not track IDs as tracks get destroyed with playlists when a new playlist goes live.